### PR TITLE
Update repositories LLVM

### DIFF
--- a/llvm-tics/build.sh
+++ b/llvm-tics/build.sh
@@ -3,12 +3,12 @@
 BASE_DIR=$(pwd)
 
 # Clone LLVM and Clang
-git clone http://llvm.org/git/llvm.git
+git clone https://github.com/llvm-mirror/llvm.git
 pushd llvm
 git reset --hard be2b2c32d38
 popd
 
-git clone http://llvm.org/git/clang.git
+git clone https://github.com/llvm-mirror/clang.git
 pushd clang
 git reset --hard 52ed5ec631
 popd


### PR DESCRIPTION
## Context of this PR
The repository of LLVM moved to GitHub https://github.com/llvm/llvm-project.git. Even though the specific commit is visible on GitHub in that repository, it does not contain the actual commit in the repository (see [this](https://stackoverflow.com/questions/65728429/git-checkout-a-branchless-commit) for more details). The right repository is now hosted on https://github.com/llvm-mirror/llvm. 

The repository of clang also moved.

## Summary of changes
- Update the repository URLs 

Closes #1 